### PR TITLE
safe() method missing null comparison condition...

### DIFF
--- a/babyparse.js
+++ b/babyparse.js
@@ -170,7 +170,7 @@
 		// Encloses a value around quotes if needed (makes a value safe for CSV insertion)
 		function safe(str, col)
 		{
-			if (typeof str === "undefined")
+			if (typeof str === "undefined" || str === null)
 				return "";
 
 			str = str.toString().replace(/"/g, '""');


### PR DESCRIPTION
causing a TypeError to be thrown if field is null; Patching from papaparse.
