### PR TITLE
Added ability to parse directly from a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ parsed = Baby.parse(csv);
 rows = parsed.data;
 ```
 
+
+Parse File(s)
+-----
+
+```js
+// Parse single file
+parsed = Baby.parseFiles(file[, config])
+
+rows = parsed.data
+```
+
+```js
+// Parse multiple files
+// Files can be either an array of strings or objects { file: filename[, config: config] }
+// When using and array of objects and you include a config it will be used in place of the global config
+parsed = Baby.parseFiles(files[, globalConfig])
+
+rows = parsed[index].data
+```
+
+
 For a complete understanding of the power of this library, please refer to the [Papa Parse web site](http://papaparse.com).
 
 

--- a/babyparse.js
+++ b/babyparse.js
@@ -28,6 +28,7 @@
 
 	var Baby = {};
 	Baby.parse = CsvToJson;
+	Baby.parseFiles = ParseFiles;
 	Baby.unparse = JsonToCsv;
 	Baby.RECORD_SEP = String.fromCharCode(30);
 	Baby.UNIT_SEP = String.fromCharCode(31);
@@ -37,13 +38,46 @@
 	Baby.Parser = Parser;				// For testing/dev only
 	Baby.ParserHandle = ParserHandle;	// For testing/dev only
 
+	function ParseFiles(_input, _config)
+	{
+		if (Array.isArray(_input)) {
+			var results = [];
+			_input.forEach(function(input) {
+				if(typeof input === 'object')
+					results.push(ParseFiles(input.file, input.config));
+				else
+					results.push(ParseFiles(input, _config));
+			});
+			return results;
+		} else {
+			var results = {
+				data: [],
+				errors: []
+			};
+			if ((/(\.csv|\.txt)$/).test(_input)) {
+				try {
+					var contents = fs.readFileSync(_input).toString();
+					return CsvToJson(contents, _config);
+				} catch (err) {
+					results.errors.push(err);
+					return results;
+				}
+			} else {
+				results.errors.push({
+					type: '',
+					code: '',
+					message: 'Unsupported file type.',
+					row: ''
+				});
+				return results;
+			}
+		}
+	}
 
 	function CsvToJson(_input, _config)
 	{
 		var config = copyAndValidateConfig(_config);
 		var ph = new ParserHandle(config);
-		if ((/(\.csv|\.txt)$/).test(_input))
-			_input = fs.readFileSync(_input).toString();
 		var results = ph.parse(_input);
 		if (isFunction(config.complete))
 			config.complete(results);

--- a/babyparse.js
+++ b/babyparse.js
@@ -42,6 +42,8 @@
 	{
 		var config = copyAndValidateConfig(_config);
 		var ph = new ParserHandle(config);
+		if ((/(\.csv|\.txt)$/).test(_input))
+			_input = fs.readFileSync(_input).toString();
 		var results = ph.parse(_input);
 		if (isFunction(config.complete))
 			config.complete(results);


### PR DESCRIPTION
Only works for files with a csv or txt extension.

Example:
parsed = Baby.parse('tests/sample.csv');

TODO:
Add some graceful error handling when passing invalid file path or name (nonexistent file).
Add some graceful error handling for unsupported file type (non txt or cvs extension).