### PR TITLE
Fix reference error when fs is not defined

### DIFF
--- a/babyparse.js
+++ b/babyparse.js
@@ -37,7 +37,9 @@
 	Baby.DefaultDelimiter = ",";		// Used if not specified and detection fails
 	Baby.Parser = Parser;				// For testing/dev only
 	Baby.ParserHandle = ParserHandle;	// For testing/dev only
-
+	
+	var fs = fs || require('fs')
+	
 	function ParseFiles(_input, _config)
 	{
 		if (Array.isArray(_input)) {


### PR DESCRIPTION
Ran into this issue when using `Baby.parseFiles`. Not sure if I was missing something, but this seemed easy enough to fix.