### PR TITLE
fixed double call of complete Parser method

### DIFF
--- a/babyparse.js
+++ b/babyparse.js
@@ -81,8 +81,6 @@
 		var config = copyAndValidateConfig(_config);
 		var ph = new ParserHandle(config);
 		var results = ph.parse(_input);
-		if (isFunction(config.complete))
-			config.complete(results);
 		return results;
 	}
 


### PR DESCRIPTION
CsvToJson calls the complete property twice -- once explicitly in the CsvToJson definition, and once during the parse method of the ParseHandle object. Removed the explicit call in the function definition to leave other ParseHandle functionality intact.