### PR TITLE
Add compatibility for environments that don't support require + fs

### DIFF
--- a/babyparse.js
+++ b/babyparse.js
@@ -45,7 +45,7 @@
 	function ParseFiles(_input, _config)
 	{
 		if (typeof fs === "undefined") {
-			throw new {
+			throw {
 				code: -1,
 				message: "ParseFiles is not supported in your environment due to a missing dependency (fs)"
 			};

--- a/babyparse.js
+++ b/babyparse.js
@@ -37,11 +37,19 @@
 	Baby.DefaultDelimiter = ",";		// Used if not specified and detection fails
 	Baby.Parser = Parser;				// For testing/dev only
 	Baby.ParserHandle = ParserHandle;	// For testing/dev only
-	
-	var fs = fs || require('fs')
+
+	if (typeof require !== "undefined") {
+		var fs = fs || require('fs');
+	}
 	
 	function ParseFiles(_input, _config)
 	{
+		if (typeof fs === "undefined") {
+			throw new {
+				code: -1,
+				message: "ParseFiles is not supported in your environment due to a missing dependency (fs)"
+			};
+		}
 		if (Array.isArray(_input)) {
 			var results = [];
 			_input.forEach(function(input) {


### PR DESCRIPTION
This PR adds compatibility for environments that don't support require + fs.

My use case for this change came about when I needed to use this library in an environment running a legacy version of SpiderMonkey.
